### PR TITLE
Fix syntax error in worddict.

### DIFF
--- a/kettlefish.py
+++ b/kettlefish.py
@@ -39,7 +39,7 @@ REMYSPEAK = {
         "hundo": "a hundred",
         "step out": "smoke",
         "homeboy": "dude",
-        "homegirl", "girl",
+        "homegirl": "girl",
         "wat": "what",
         "chops": "skills",
         "foo": "skill",


### PR DESCRIPTION
Does what it says on the tin. Fixes a syntax error that prevents the script from running.
