### PR TITLE
Reword bot output to be more accurate.

### DIFF
--- a/kettlebot.py
+++ b/kettlebot.py
@@ -52,7 +52,7 @@ class KettleBot(IRCClient):
             translated = translate_remyspeak(msg)
             display = re.sub(r'(\+\+)|(--)', '', translated)
             if not msg.lower() == translated.lower():
-                self.msg(channel, 'What {} meant to say was: {}'.format(
+                self.msg(channel, 'What {} means is: {}'.format(
                                     user, display))
 
         if channel == self.nickname:


### PR DESCRIPTION
I propose this change to kettlebot's output. My reasoning is that when @decause says something, he meant to say it that way, and decauslang is part of what makes Remy so groovy. I think saying things this way is less negative-sounding. Since it is essentially the entire front-facing portion of the program, I think there should be 2 +1s before we merge it in. @Qalthos's input is requested too, since he wrote the entire bot part of this suite.
